### PR TITLE
Correcao Erro no markdown dos primeiros passos

### DIFF
--- a/Manual/quickstart.md
+++ b/Manual/quickstart.md
@@ -22,7 +22,7 @@ Lembre-se de desativar antivirus e vpn para ao ExeKaliburr poder performar norma
 ### Kali Linux
 Caso você esteja utilizando um sistema operacional Kali Linux, é possível a execução do Kalibur sem a instalação do Docker.
 ```bash
-curl -O -L https://raw.githubusercontent.com/ExeKaliBurr/SBSeg2023/main/Source/kalibur 
+curl -O -L https://raw.githubusercontent.com/ExeKaliBurr/SBSeg2023/main/Source/exekaliburr 
 ```
 Depois execute os seguintes comandos:
 ```bash


### PR DESCRIPTION
Olá, eu estava com problema para realizar os primeiros passos no kali linux até que notei que nas instruções falava para baixar um arquivo chamado "kalibur", porém isso dava erro. Tentei alterar o final do comando "curl -O -L https://raw.githubusercontent.com/ExeKaliBurr/SBSeg2023/main/Source/kalibur" para "curl -O -L https://raw.githubusercontent.com/ExeKaliBurr/SBSeg2023/main/Source/exekaliburr " e deu certo 